### PR TITLE
[path_provider]Fix the comment of `getApplicationDocumentsDirectory` method

### DIFF
--- a/packages/path_provider/path_provider/lib/path_provider.dart
+++ b/packages/path_provider/path_provider/lib/path_provider.dart
@@ -128,7 +128,7 @@ Future<Directory> getLibraryDirectory() async {
 /// On iOS, this uses the `NSDocumentDirectory` API. Consider using
 /// [getApplicationSupportDirectory] instead if the data is not user-generated.
 ///
-/// On Android, this uses the `getDataDirectory` API on the context. Consider
+/// On Android, this uses the `getDir` API on the context. Consider
 /// using [getExternalStorageDirectory] instead if data is intended to be visible
 /// to the user.
 ///


### PR DESCRIPTION

`getDataDirectory` should be `getDir`.

Code in the plugin:
https://github.com/flutter/plugins/blob/5bf7fb0360aa70571c46d5b0ac64949fc81a0dfd/packages/path_provider/path_provider/android/src/main/java/io/flutter/plugins/pathprovider/PathProviderPlugin.java#L79
```kotlin
  private String getPathProviderApplicationDocumentsDirectory() {
    return PathUtils.getDataDirectory(context);
  }
```

PathUtils code in Flutter engine:
https://github.com/flutter/engine/blob/1509b7b6b8313ebe0f7e216ddd59f9ccae399ea1/shell/platform/android/io/flutter/util/PathUtils.java#L15
```kotlin
  public static String getDataDirectory(Context applicationContext) {
    return applicationContext.getDir("flutter", Context.MODE_PRIVATE).getPath();
  }
```

The `getDataDirectory` in the comment is inaccurate, the correct one should be `getDir`.




## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.